### PR TITLE
fix: gets rid of node engine >= 17 requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Thumbs.db
 .netbeans
 nbproject
 .node_history
+dist
 
 # IDEs & Text Editors
 .idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@apidevtools/json-schema-ref-parser",
-  "version": "0.0.0-dev",
+  "name": "@anttiviljami/json-schema-ref-parser",
+  "version": "9.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@apidevtools/json-schema-ref-parser",
-      "version": "0.0.0-dev",
+      "name": "@anttiviljami/json-schema-ref-parser",
+      "version": "9.2.1",
       "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
@@ -36,9 +36,6 @@
         "semantic-release-plugin-update-version-in-files": "^1.1.0",
         "shx": "^0.3.2",
         "typescript": "^4.0.5"
-      },
-      "engines": {
-        "node": ">= 17"
       },
       "funding": {
         "url": "https://github.com/sponsors/philsturgeon"

--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
   "browser": {
     "fs": false
   },
-  "engines": {
-    "node": ">= 17"
-  },
   "files": [
     "lib"
   ],
@@ -54,7 +51,7 @@
     "lint": "eslint lib test/fixtures test/specs",
     "test": "npm run test:node && npm run test:typescript && npm run test:browser && npm run lint",
     "test:node": "mocha",
-    "test:browser": "cross-env NODE_OPTIONS=--openssl-legacy-provider karma start --single-run",
+    "test:browser": "cross-env karma start --single-run",
     "test:typescript": "tsc --noEmit --strict --lib esnext,dom test/specs/typescript-definition.spec.ts",
     "coverage": "npm run coverage:node && npm run coverage:browser",
     "coverage:node": "nyc node_modules/mocha/bin/mocha",


### PR DESCRIPTION
## Context

A breaking change was introduced on this [PR#294](https://github.com/APIDevTools/json-schema-ref-parser/pull/294), causing everyone that depends on versions above 9.0.9 to now have to update their node engines to >= v17.

There is also an open issue on the `json-schema-ref-parser` repo regarding this same problem [issue#298](https://github.com/APIDevTools/json-schema-ref-parser/issues/298).

## Change
 
This PR, removed the node engine limitation and gets rid of a node17 specific flag.

## Tests

All tests pass locally on MacOS 13 (Ventura); not sure about other environments. Either way, the only reason the engine was updated was due to some browser test, and since the `json-schema-ref-parser` CI points to Node 17, the tests should keep passing on their pipelines. The node engine requirement was just nonsense.