### PR TITLE
Don't resolve URL for non-HTTP strings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,9 @@ $RefParser.prototype.parse = async function parse (path, schema, options, callba
   }
 
   // Resolve the absolute path of the schema
-  args.path = url.resolve(url.cwd(), args.path);
+  if(pathType == "http") {
+    args.path = url.resolve(url.cwd(), args.path);
+  }  
 
   if (args.schema && typeof args.schema === "object") {
     // A schema object was passed-in.


### PR DESCRIPTION
If Path is from filesystem, this call will throw an exception. Perhaps there is a different fix for this logic, but this is my first stab at doing so. Feel free to discard.

Personally, I would not feel comfortable merging this PR in without some additional test cases. However, this does fix the problems I was having with using the `openapi-backend` project 🤔

## Tangent

I noticed the upstream https://apitools.dev/json-schema-ref-parser/ project is looking for new maintainers. I would open an Issue to discuss this, but Issues are not available on this forked repo. @anttiviljami, is it your intent to take over the maintenance of this project (`json-schema-ref-parser`)? I ask because I see a **ton** of potential in `openapi-backend`, which is dependent on `json-schema-ref-parser`. As such, I am starting to brainstorm approaches around how to best support/contribute to these projects 😀 In this case, if you are planning on maintaining `json-schema-ref-parser`, awesome! If you are not, then I may attempt to get more involved in the maintenance of `json-schema-ref-parser` myself.

## Simple Test

```js
const to = "./openapi.yaml";
const fromPath = "C:\\";
let resolvedUrl = new URL(to, new URL(fromPath, "resolve://"));  
console.log(resolvedUrl)
```

The above throws

```sh
node:internal/url:566
  throw new ERR_INVALID_URL(input);
  ^

TypeError [ERR_INVALID_URL]: Invalid URL
    at new NodeError (node:internal/errors:399:5)
    at URL.onParseError (node:internal/url:566:9)
    at new URL (node:internal/url:646:5)
    at Object.<anonymous> (F:\Cloud Storage\SourceControl\sync-bot-ts\what.js:3:19)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47 {
  input: './openapi.yaml',
  code: 'ERR_INVALID_URL'
}
```